### PR TITLE
Set GlobalPermission model's verbose name empty

### DIFF
--- a/global_permissions/models.py
+++ b/global_permissions/models.py
@@ -31,8 +31,8 @@ class GlobalPermission(Permission):
 
     class Meta:
         proxy = True
-        verbose_name = _('Global Permission')
-        verbose_name_plural = _('Global Permissions')
+        verbose_name = ''
+        verbose_name_plural = ''
 
     def save(self, *args, **kwargs):
         content_type_kwargs = {'app_label': self._meta.app_label,


### PR DESCRIPTION
I assume, that if there is global permissions so that should not to be related to any models in admin views. 
So shorter __str__ looks more usable in admin views.
It
![image](https://user-images.githubusercontent.com/11770485/33380378-9118b8d4-d523-11e7-952a-7e3c265022f3.png)
looks more usable than
![image](https://user-images.githubusercontent.com/11770485/33380387-95fa62bc-d523-11e7-83ab-9e201eec98ee.png)